### PR TITLE
Add minimumInputLength option

### DIFF
--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -54,7 +54,11 @@ uis.directive('uiSelectChoices',
         scope.$watch('$select.search', function(newValue) {
           if(newValue && !$select.open && $select.multiple) $select.activate(false, true);
           $select.activeIndex = $select.tagging.isActivated ? -1 : 0;
-          $select.refresh(attrs.refresh);
+          if (!attrs.minimumInputLength || $select.search.length >= attrs.minimumInputLength) {
+            $select.refresh(attrs.refresh);
+          } else {
+            $select.items = [];
+          }
         });
 
         attrs.$observe('refreshDelay', function() {


### PR DESCRIPTION
Should be added as "minimum-input-length" on ui-select-choices directive

You can see a working version here (first select only):
http://plnkr.co/edit/vd0qiDmGuvOa8CfrCy5s?p=preview

This fixes #161.

Let me know if there's something wrong or something to improve.
